### PR TITLE
Actually check for `pct`

### DIFF
--- a/pct_ssh.py
+++ b/pct_ssh.py
@@ -540,7 +540,7 @@ class Connection(ConnectionBase):
 
     def _set_version(self):
         # Check for 'pct' first in case the host is a proxmox server
-        if self._exec_command("type lxc", None, False)[0] == 0:
+        if self._exec_command("type pct", None, False)[0] == 0:
             self.lxc_version = "pct"
             display.vvv("PCT")
         # LXC v1 uses 'lxc-info', 'lxc-attach' and so on


### PR DESCRIPTION
I noticed that [`_set_version()`](https://github.com/jbrubake/ansible-pct-ssh/blob/046373b618c8c72b96a8c02f6dec254fd5976eb7/pct_ssh.py#L541-L543) claims to check for `pct` first, but actually checks for `lxc` (which fails on Proxmox, and therefore the plugin settles on LXC v1). Running a playbook with `-vvv` confirms that `lxc-attach` and similar commands are used, instead of the Proxmox `pct` command.

I'm guessing it's just a typo; in any case this PR should fix it.